### PR TITLE
ci: automate Go protobuf releases

### DIFF
--- a/.github/workflows/release-go.yml
+++ b/.github/workflows/release-go.yml
@@ -1,0 +1,59 @@
+name: Release Go
+
+on:
+  schedule:
+    # The specification release workflow runs on Sunday. Poll daily so a
+    # delayed release is picked up without relying on a second repository's
+    # workflow dispatch permissions.
+    - cron: "0 4 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Substrait release tag to generate (for example, v0.102.0)"
+        required: false
+        type: string
+
+concurrency:
+  group: release-go
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.repository == 'substrait-io/substrait-protobuf'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Resolve specification release
+        id: spec
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUESTED_VERSION: ${{ inputs.version }}
+        run: |
+          if [ -n "$REQUESTED_VERSION" ]; then
+            version="$REQUESTED_VERSION"
+          else
+            version="$(gh api repos/substrait-io/substrait/releases/latest --jq '.tag_name')"
+          fi
+          printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install Buf
+        uses: bufbuild/buf-action@v1.5.0
+        with:
+          version: 1.50.0
+          github_token: ${{ github.token }}
+          setup_only: true
+
+      - name: Generate and publish Go protobufs
+        env:
+          GIT_AUTHOR_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_AUTHOR_NAME: github-actions[bot]
+          GIT_COMMITTER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+          GIT_COMMITTER_NAME: github-actions[bot]
+        run: ./generate-go.sh "${{ steps.spec.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Protobufs are generated based on tagged versions of the Substrait specification 
 # Languages
 
 ## Go
-The generated Go protobuf code is not include in the `main` branch. Instead, each version of the spec has a dedicated branch and tag from which it can be accessed.
+The generated Go protobuf code is not included in the `main` branch. Instead, each version of the spec has a dedicated branch and tag from which it can be accessed.
 
-Generation is managed by the `generate-go.sh` script which is invoked with a specific tag. For example
+Generation is managed by the `generate-go.sh` script, which is invoked with a specific tag. For example
 ```sh
 ./generate-go.sh v0.64.0
 ```
@@ -19,6 +19,11 @@ will:
 4. Commit the generated code, and tag the commit with `go/v0.64.0`
 
 Users can then access the code by referencing the tag.
+
+The `Release Go` workflow checks the latest Substrait release daily and skips
+versions that already have a `go/<version>` tag. A `workflow_dispatch` input
+can be used to generate a specific release when a scheduled run needs to be
+replayed.
 
 ## Java
 TODO

--- a/generate-go.sh
+++ b/generate-go.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+set -eu
+
 # Ensure exactly one argument is provided
 if [ "$#" -ne 1 ]; then
     echo "Usage: $0 <version>"
@@ -13,34 +15,66 @@ if [ "$CURRENT_BRANCH" != "main" ]; then
     exit 2
 fi
 
-VERSION="$1"
 SPEC_REPO_URL="https://github.com/substrait-io/substrait.git"
+SPEC_VERSION="$1"
+
+case "$SPEC_VERSION" in
+    */*)
+        echo "❌ Spec version must not contain '/': $SPEC_VERSION" >&2
+        exit 1
+        ;;
+    v[0-9]*.[0-9]*.[0-9]*)
+        ;;
+    *)
+        echo "❌ Spec version must be a release tag such as v0.102.0: $SPEC_VERSION" >&2
+        exit 1
+        ;;
+esac
 
 # Use git ls-remote to check if the specific tag exists
-echo "Checking if tag '$VERSION' exists in $SPEC_REPO_URL"
-if git ls-remote --tags "$SPEC_REPO_URL" "refs/tags/$VERSION" | grep -q .; then
-    echo "✅ Tag '$VERSION' exists."
+echo "Checking if spec version $SPEC_VERSION exists in $SPEC_REPO_URL"
+if git ls-remote --exit-code --tags "$SPEC_REPO_URL" "refs/tags/$SPEC_VERSION" >/dev/null 2>&1; then
+    echo "✅ Spec version $SPEC_VERSION exists"
 else
-    echo "❌ Tag '$VERSION' does NOT exist."
+    echo "❌ Spec version $SPEC_VERSION does NOT exist" >&2
     exit 3
 fi
 
-BRANCH_NAME="releases/go/$VERSION"
-echo "🔨 Creating new branch: $BRANCH_NAME"
-git checkout -B "$BRANCH_NAME"
+GO_VERSION_TAG="go/$SPEC_VERSION"
+BRANCH_NAME="releases/$GO_VERSION_TAG"
 
-TARGET="https://github.com/substrait-io/substrait.git#tag=$VERSION"
+# A tag is the publication marker. Do not regenerate or mutate an existing release.
+if git rev-parse --verify --quiet "refs/tags/$GO_VERSION_TAG" >/dev/null 2>&1 || \
+    git ls-remote --exit-code --tags origin "refs/tags/$GO_VERSION_TAG" >/dev/null 2>&1; then
+    echo "✅ Protobufs for $SPEC_VERSION already exist"
+    exit 0
+fi
+
+if git ls-remote --exit-code --heads origin "$BRANCH_NAME" >/dev/null 2>&1; then
+    echo "❌ Release branch $BRANCH_NAME exists without tag $GO_VERSION_TAG" >&2
+    exit 4
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+    echo "❌ ./generate-go must be invoked with a clean working tree" >&2
+    exit 4
+fi
+
+echo "🔨 Creating new branch: $BRANCH_NAME"
+git checkout -B "$BRANCH_NAME" main
+
+TARGET="https://github.com/substrait-io/substrait.git#tag=$SPEC_VERSION"
 echo "🔧 Executing Protobuf code generation for $TARGET"
 buf generate "$TARGET"
 
 echo "Committing generated code"
 
 git add go/substraitpb
-git commit -m "generated go/substraitpb for $VERSION"
-git push --set-upstream origin "$BRANCH_NAME"
+git commit --allow-empty -m "generated go/substraitpb for $SPEC_VERSION"
 
-VERSION_TAG="go/$VERSION"
-git tag "$VERSION_TAG" -m "Generated Go code for spec version $VERSION"
-git push origin "$VERSION_TAG"
+git tag "$GO_VERSION_TAG" -m "Generated Go code for spec version $SPEC_VERSION"
+# Publish branch and tag together so an interrupted run cannot leave a branch
+# without its release tag.
+git push --atomic origin "$BRANCH_NAME" "$GO_VERSION_TAG"
 
 git checkout main


### PR DESCRIPTION
## Summary
Automate Go protobuf generation for each Substrait specification release, closing the gap tracked in #4. This is a replacement for #5 based on current `main`.

## Changes
- Poll the latest specification release daily and support manual replay for a selected version.
- Use the repository `GITHUB_TOKEN` and pinned Buf setup instead of repository-specific app secrets.
- Harden `generate-go.sh` with release-tag validation, clean-tree checks, idempotent tag/branch checks, and atomic branch/tag publication.
- Document scheduled and manual release behavior.

## Testing
- `shellcheck generate-go.sh`
- `sh -n generate-go.sh`
- `actionlint .github/workflows/release-go.yml`
- Buf v1.50 generation against `v0.102.0` in an isolated directory.
- `go test ./...` against generated `v0.102.0` Go artifacts.
- Isolated bare Git remote run confirmed atomic branch/tag publication without publishing to GitHub.

## Did this cause any problems?
Rollback/revert this commit and disable the workflow.

Closes #4